### PR TITLE
feat: Dockerfile: move to debian11 base, add Tomcat Native packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
-FROM gcr.io/distroless/java-debian10:11
+FROM debian:11 AS builder
+RUN apt-get update \
+    && apt-get install --yes libtcnative-1
+
+FROM gcr.io/distroless/java-debian11:11
 WORKDIR /
 COPY scripts/Dpkg.java Dpkg.java
 COPY target/*.jar app.jar
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libtcnative* /usr/lib/x86_64-linux-gnu/libapr* /usr/lib/x86_64-linux-gnu/
 RUN ["java", "Dpkg.java"]
 USER 65534:65534
 CMD ["-Djava.security.egd=file:/dev/./urandom", "app.jar"]


### PR DESCRIPTION
With libtcnative and libapr, Tomcat can use OpenSSL for encryption which is more efficient than JSSE. Simple measurements show 30-40% speedup in TLS handshakes.

No configuration changes needed, the embedded Tomcat will pick up the library files automatically if they are present:
```
2021-11-21 21:52:15.169  INFO 1 --- [           main] o.a.catalina.core.AprLifecycleListener   : Loaded Apache Tomcat Native library [1.2.26] using APR version [1.7.0].
2021-11-21 21:52:15.170  INFO 1 --- [           main] o.a.catalina.core.AprLifecycleListener   : APR capabilities: IPv6 [true], sendfile [true], accept filters [false], random [true].
2021-11-21 21:52:15.172  INFO 1 --- [           main] o.a.catalina.core.AprLifecycleListener   : APR/OpenSSL configuration: useAprConnector [false], useOpenSSL [true]
2021-11-21 21:52:15.180  INFO 1 --- [           main] o.a.catalina.core.AprLifecycleListener   : OpenSSL successfully initialized [OpenSSL 1.1.1k  25 Mar 2021]
```