### PR TITLE
Chore: Update CWA-Parent to 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>app.coronawarn</groupId>
         <artifactId>cwa-parent</artifactId>
-        <version>1.5</version>
+        <version>1.6</version>
         <relativePath/>
     </parent>
     <groupId>eu.europa.ec.dgc</groupId>


### PR DESCRIPTION
### Update the parent pom (cwa-parent) to the last released version.
  
  This PR will update several dependencies within this project.
  Please do a full integration test before merging this PR.
  
  Also please have a look on the [Release Notes](https://github.com/corona-warn-app/cwa-parent/releases/tag/1.6) of this new CWA-Parent version.